### PR TITLE
Update to fix building with libnx 4.0.0

### DIFF
--- a/nanovg/include/nanovg/framework/CApplication.h
+++ b/nanovg/include/nanovg/framework/CApplication.h
@@ -30,7 +30,7 @@ constexpr void CApplication::chooseFramebufferSize(uint32_t& width, uint32_t& he
             width = 1280;
             height = 720;
             break;
-        case AppletOperationMode_Docked:
+        case AppletOperationMode_Console:
             width = 1920;
             height = 1080;
             break;

--- a/nanovg/source/framework/CApplication.cpp
+++ b/nanovg/source/framework/CApplication.cpp
@@ -20,7 +20,7 @@ void CApplication::run()
 {
     u64 tick_ref = armGetSystemTick();
     u64 tick_saved = tick_ref;
-    bool focused = appletGetFocusState() == AppletFocusState_Focused;
+    bool focused = appletGetFocusState() == AppletFocusState_InFocus;
 
     onOperationMode(appletGetOperationMode());
 
@@ -40,7 +40,7 @@ void CApplication::run()
                 {
                     bool old_focused = focused;
                     AppletFocusState state = appletGetFocusState();
-                    focused = state == AppletFocusState_Focused;
+                    focused = state == AppletFocusState_InFocus;
 
                     onFocusState(state);
                     if (focused == old_focused)

--- a/source/test_dk.cpp
+++ b/source/test_dk.cpp
@@ -80,6 +80,7 @@ class DkTest final : public CApplication
     DemoData data;
     PerfGraph fps;
     float prevTime;
+    PadState pad;
 
 public:
     DkTest()
@@ -111,6 +112,9 @@ public:
         if (loadDemoData(vg, &this->data) == -1) {
             printf("Failed to load demo data!\n");
         }
+
+        padConfigureInput(1, HidNpadStyleSet_NpadStandard);
+        padInitializeDefault(&pad);
     }
 
     ~DkTest()
@@ -252,13 +256,14 @@ public:
 
     bool onFrame(u64 ns) override
     {
-        hidScanInput();
-        u64 kDown = hidKeysDown(CONTROLLER_P1_AUTO);
-        u64 kHeld = hidKeysHeld(CONTROLLER_P1_AUTO);
+        padUpdate(&pad);
+        u64 kDown = padGetButtonsDown(&pad);
         if (kDown & KEY_PLUS)
             return false;
 
-        render(ns, kHeld & KEY_MINUS);
+        // hidKeysHeld alternate not provided with libnx v4.0.0 +
+        // using kDown instead. Renders for a single frame when pressed
+        render(ns, kDown & KEY_MINUS);
         return true;
     }
 };


### PR DESCRIPTION
**NOTE**: An alternate to `hidKeysHeld` function was not provided by libnx. As a result, the call for `hidKeysHeld` has been replaced by `padGetButtonsDown` (function replacing `hidKeysDown`). This also means that the widgets window will be visible for 1 frame only when the `-` button is pressed as a consequence.